### PR TITLE
Add opt-in Flow triggers for the display connector buttons (V2 connector type 3)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1607,7 +1607,7 @@ class MyApp extends Homey.App
 				}
 			}
 		}
-		else if (connectorType === 2)
+		else if ((connectorType === 2) || (connectorType === 3))
 		{
 			if (!checkSEMVerGreaterOrEqual(firmwareVersion, '2.0.0'))
 			{
@@ -2917,7 +2917,7 @@ class MyApp extends Homey.App
 		const tokens = { state: onoff, page };
 		const state = {
 			left_right,
-			displaybutton: display_button === 2 ? 'display' : 'button',
+			displaybutton: ((display_button === 2) || (display_button === 3)) ? 'display' : 'button',
 			config: parseInt(configID, 10) + 1,
 			state: button_state,
 		};
@@ -3026,7 +3026,7 @@ class MyApp extends Homey.App
 			button.toplabel = '';
 			button.topics = [];
 
-			if (connectorType === 2)
+			if ((connectorType === 2) || (connectorType === 3))
 			{
 				button.leds = [];
 			}

--- a/app.json
+++ b/app.json
@@ -3086,6 +3086,19 @@
           ]
         },
         {
+          "id": "displayButtonEvents",
+          "type": "checkbox",
+          "label": {
+            "en": "Display button Flow triggers",
+            "nl": "Flow-triggers voor displayknoppen"
+          },
+          "hint": {
+            "en": "Send click, long press and release events for the two buttons next to the display so they can trigger Flows (configuration button cards). Note: on panels with multiple pages these buttons also navigate between pages.",
+            "nl": "Stuur klik-, lang indrukken- en loslaat-events voor de twee knoppen naast het display zodat ze Flows kunnen starten (configuratieknop-kaarten). Let op: bij meerdere pagina's bladeren deze knoppen ook door de pagina's."
+          },
+          "value": false
+        },
+        {
           "id": "temperatureCalibration",
           "type": "number",
           "label": {

--- a/drivers/panel_hardware/device.js
+++ b/drivers/panel_hardware/device.js
@@ -30,6 +30,7 @@ class PanelDevice extends Device
 		const settings = this.getSettings();
 
 		this.ip = settings.address;
+		this.displayButtonEvents = settings.displayButtonEvents === true;
 
 		if (!settings.statusbar)
 		{
@@ -424,6 +425,20 @@ class PanelDevice extends Device
 			{
 				throw new Error('Invalid MAC address');
 			}
+		}
+
+		if (changedKeys.includes('displayButtonEvents'))
+		{
+			this.displayButtonEvents = newSettings.displayButtonEvents === true;
+
+			// Reconfigure the connectors and republish the panel configuration so the
+			// display connector's buttons are added or removed from the panel configuration
+			setImmediate(() =>
+			{
+				this.configureConnectors(newSettings)
+					.then(() => this.uploadConfigurations())
+					.catch(this.error);
+			});
 		}
 
 		let refreshDateAndTime = false;
@@ -1461,14 +1476,14 @@ class PanelDevice extends Device
 				}
 			}
 
-			if (connectType !== 1) // 0 = not fitted, 1 = button panel, 2 = display
+			if (connectType !== 1) // 0 = not fitted, 1 = button panel, 2 = display, 3 = display (V2 panels)
 			{
 				if (this.hasCapability(`configuration_button.connector${connector}`))
 				{
 					await this.removeCapability(`configuration_button.connector${connector}`);
 				}
 
-				if (connectType !== 2)
+				if ((connectType !== 2) && ((connectType !== 3) || (this.displayButtonEvents !== true)))
 				{
 					await this.removeCapability(`left_button.connector${connector}`);
 					await this.removeCapability(`right_button.connector${connector}`);
@@ -1712,7 +1727,7 @@ class PanelDevice extends Device
 		parameters.buttonCapability = `${parameters.side}_button.connector${parameters.connector}`;
 		parameters.fromButton = true;
 		const connectorType = this.getSetting(`connect${parameters.connector}Type`);
-		parameters.configNo = connectorType === 2 ? null : this.getCapabilityValue(`configuration_button.connector${parameters.connector}`);
+		parameters.configNo = ((connectorType === 2) || (connectorType === 3)) ? null : this.getCapabilityValue(`configuration_button.connector${parameters.connector}`);
 		await this.processClickMessage(parameters);
 	}
 
@@ -1907,7 +1922,7 @@ class PanelDevice extends Device
 		parameters.connector = (MQTTMessage.idx / 2) | 0;
 		parameters.side = (MQTTMessage.idx % 2) === 0 ? 'left' : 'right';
 		parameters.connectorType = this.getSetting(`connect${parameters.connector}Type`);
-		parameters.configNo = parameters.connectorType === 2 ? this.getCapabilityValue('configuration_display') : this.getCapabilityValue(`configuration_button.connector${parameters.connector}`);
+		parameters.configNo = ((parameters.connectorType === 2) || (parameters.connectorType === 3)) ? this.getCapabilityValue('configuration_display') : this.getCapabilityValue(`configuration_button.connector${parameters.connector}`);
 		parameters.buttonCapability = `${parameters.side}_button.connector${parameters.connector}`;
 		parameters.value = !this.buttonValues.get(`${parameters.side}_${parameters.connector}_${parameters.page}`);
 
@@ -1937,7 +1952,7 @@ class PanelDevice extends Device
 	{
 		// Check if a large display or if no configuration assigned to this connector
 		let config = null;
-		if ((parameters.configNo != null) && (parameters.connectorType !== 2))
+		if ((parameters.configNo != null) && (parameters.connectorType !== 2) && (parameters.connectorType !== 3))
 		{
 			if (!parameters.page)
 			{
@@ -2154,7 +2169,7 @@ class PanelDevice extends Device
 		}
 
 		let buttonPanelConfiguration = null;
-		if (parameters.configNo != null)
+		if ((parameters.configNo != null) && (parameters.connectorType !== 2) && (parameters.connectorType !== 3))
 		{
 			buttonPanelConfiguration = this.homey.app.buttonConfigurations[parameters.configNo];
 			if (buttonPanelConfiguration[`${parameters.side}DisableLongRepeat`] && (repeatCount > 0))
@@ -2171,7 +2186,16 @@ class PanelDevice extends Device
 		this.longPressOccurred.set(`${parameters.connector}_${parameters.side}_${parameters.page}`, repeatCount + 1);
 		this.homey.app.triggerButtonLongPress(this, parameters.side === 'left', parameters.connector + 1, repeatCount, parameters.page);
 
-		if (buttonPanelConfiguration !== null)
+		if ((parameters.connectorType === 2) || (parameters.connectorType === 3))
+		{
+			// Display connector buttons: fire the configuration button trigger so long presses can start flows
+			if (repeatCount === 0)
+			{
+				const value = this.buttonValues.get(`${parameters.side}_${parameters.connector}_${parameters.page}`);
+				this.homey.app.triggerConfigButton(this, parameters.side, parameters.connectorType, parameters.configNo, 'long', value, parameters.page);
+			}
+		}
+		else if (buttonPanelConfiguration !== null)
 		{
 			const value = this.buttonValues.get(`${parameters.side}_${parameters.connector}_${parameters.page}`);
 
@@ -2208,7 +2232,7 @@ class PanelDevice extends Device
 		}
 
 		// Check if a large display or if no configuration assigned to this connector
-		if ((parameters.connectorType === 2) || (parameters.configNo == null))
+		if ((parameters.connectorType === 2) || (parameters.connectorType === 3) || (parameters.configNo == null))
 		{
 			this.setLEDOnOff(config, null, buttonIdx, parameters.page, false);
 			if (parameters.page === this.page)
@@ -2349,9 +2373,20 @@ class PanelDevice extends Device
 					configNo = this.getCapabilityValue(`configuration_button.connector${i}`);
 				}
 
+				// Display connectors have no button configuration, but a section entry must still be
+				// generated for their two buttons so the panel publishes click events for them.
+				// Only done when the displayButtonEvents setting is enabled (default off) so
+				// existing installations keep their current behaviour.
+				// Use the display configuration number so applyButtonConfiguration can add the defaults.
+				let applyConfigNo = configNo;
+				if ((configNo == null) && (this.displayButtonEvents === true) && ((connectorType === 2) || (connectorType === 3)) && this.hasCapability('configuration_display'))
+				{
+					applyConfigNo = this.getCapabilityValue('configuration_display');
+				}
+
 				try
 				{
-					let numPages = await this.homey.app.applyButtonConfiguration(this.buttonId, connectorType, sectionConfiguration, i, configNo, this.firmwareVersion);
+					let numPages = await this.homey.app.applyButtonConfiguration(this.buttonId, connectorType, sectionConfiguration, i, applyConfigNo, this.firmwareVersion);
 					if (numPages > this.numPages)
 					{
 						this.numPages = numPages;

--- a/drivers/panel_hardware/driver.compose.json
+++ b/drivers/panel_hardware/driver.compose.json
@@ -184,6 +184,19 @@
 			]
 		},
 		{
+			"id": "displayButtonEvents",
+			"type": "checkbox",
+			"label": {
+				"en": "Display button Flow triggers",
+				"nl": "Flow-triggers voor displayknoppen"
+			},
+			"hint": {
+				"en": "Send click, long press and release events for the two buttons next to the display so they can trigger Flows (configuration button cards). Note: on panels with multiple pages these buttons also navigate between pages.",
+				"nl": "Stuur klik-, lang indrukken- en loslaat-events voor de twee knoppen naast het display zodat ze Flows kunnen starten (configuratieknop-kaarten). Let op: bij meerdere pagina's bladeren deze knoppen ook door de pagina's."
+			},
+			"value": false
+		},
+		{
 			"id": "temperatureCalibration",
 			"type": "number",
 			"label": {


### PR DESCRIPTION
## Problem

The two buttons beside the display never fire Flow triggers.

On V2 panels the display connector reports type 3, which the app does not recognise (all display checks are for type 2), so those button events would be treated as unassigned button-bar clicks. In addition, uploadAllButtonConfigurations passes configNo = null for display connectors, so applyButtonConfiguration returns before the existing "Add a default button if none was added so the clicks work to trigger flows" fallback can run. Without those buttons section entries, firmware >= 2.0.0 (which auto-creates the topics per configured button) never publishes pushbutton events for the display module's buttons.

## Change

Opt-in per device: new advanced setting "Display button Flow triggers" (displayButtonEvents, default OFF), so existing installations keep exactly their current behaviour. When enabled:

- default button entries are generated for the display connector, so the panel publishes click / long press / release events for its two buttons;
- - the left/right button capabilities are added for the display connector on V2 (type 3), matching existing V1 (type 2) behaviour;
- - "A configuration button changed state" triggers fire with Display + clicked/released/long pressed. Example use case: nudging a thermostat setpoint (- / +) from the buttons beside the display.
Behaviour-preserving fixes included unconditionally:

- connector type 3 is treated as a display in click/long-press/release processing and in triggerConfigButton's display/button mapping, so its events are labelled 'display' rather than 'button';
- - processLongPressMessage no longer looks up buttonConfigurations[configNo] for display connectors (the display configuration number is not a button configuration index).
## Testing

- Syntax and JSON validated; with the setting off all new code paths are inert (gated on type 2/3 or on the setting).
- - Baseline verified against a V2 panel (firmware 3.1.6-V2, Homey Pro 2023): today the display buttons publish nothing and no flow trigger ever fires for them.
- - I could not yet run a dev build of the app against the panel, so the enabled path is untested on hardware. Happy to test a test-branch build on my V2 panel and report back.
- - Open question flagged for review: whether adding button entries for the display connector affects the firmware's local page navigation on multi-page setups - hence the conservative opt-in default.
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135B9UWFNXqGcEKQDFCyjwG